### PR TITLE
SHOWSTOPPER bug

### DIFF
--- a/patches/IntraACL-MediaWiki-1.20.3.diff
+++ b/patches/IntraACL-MediaWiki-1.20.3.diff
@@ -666,13 +666,15 @@ index 2a24bee..8be5b38 100644
 +			// </IntraACL>
 +		}
 +		// <IntraACL>
-+		if ( !$canRead ) {
-+			global $haclgInclusionDeniedMessage;
-+			if ( $haclgInclusionDeniedMessage ) {
-+				$text = wfMsg( $haclgInclusionDeniedMessage );
-+			} elseif ( $haclgInclusionDeniedMessage === '' ) {
-+				$text = '';
-+			}
++		if (!empty($_SERVER['SERVER_NAME'])) {
++			if ( !$canRead ) {
++				global $haclgInclusionDeniedMessage;
++				if ( $haclgInclusionDeniedMessage ) {
++					$text = wfMsg( $haclgInclusionDeniedMessage );
++				} elseif ( $haclgInclusionDeniedMessage === '' ) {
++					$text = '';
++				}
++		}
  		}
 +		// </IntraACL>
  		return array(


### PR DESCRIPTION
Hi,

I added a bugfix for not checking user rights if on `console`. The check was not aware if a maintenance script was refreshing or rebuilding the wiki database. It blocked all articles with a "inclusion denied" message. This would break e.g. `maintenance/refreshLinks.php` and moreover deleting all categories from the `categorylinks` table

This bugfix will allow the maintenance scripts to run correctly.
