### PR TITLE
Patch for Mediawiki 1.27

### DIFF
--- a/includes/ACLSpecial.php
+++ b/includes/ACLSpecial.php
@@ -91,7 +91,7 @@ class IntraACLSpecial extends SpecialPage
         $q = $wgRequest->getValues();
         if ($wgUser->isLoggedIn())
         {
-            $wgOut->setPageTitle(wfMsg('hacl_special_page'));
+            $wgOut->setPageTitle(wfMessage('hacl_special_page')->text());
             $groups = $wgUser->getGroups();
             $this->isAdmin = true && array_intersect($groups, $haclgSuperGroups);
             if (!isset($q['action']) ||
@@ -109,7 +109,7 @@ class IntraACLSpecial extends SpecialPage
             ));
             if ($f == 'html_acllist')
             {
-                $wgOut->addHTML('<p style="margin-top: -8px">'.wfMsgExt('hacl_acllist_hello', 'parseinline').'</p>');
+                $wgOut->addHTML('<p style="margin-top: -8px">'.wfMessage('hacl_acllist_hello', 'parseinline')->text().'</p>');
             }
             $this->_actions($q);
             $this->$f($q);
@@ -467,7 +467,7 @@ class IntraACLSpecial extends SpecialPage
         }
         else
         {
-            $wgOut->addWikiText(wfMsg('hacl_acllist_empty'));
+            $wgOut->addWikiText(wfMessage('hacl_acllist_empty')->text());
         }
         haclfRestoreTitlePatch($patch);
     }
@@ -522,7 +522,7 @@ class IntraACLSpecial extends SpecialPage
         require(dirname(__FILE__).'/../templates/HACL_ACLList.tpl.php');
         $html = ob_get_contents();
         ob_end_clean();
-        $wgOut->setPageTitle(wfMsg('hacl_acllist'));
+        $wgOut->setPageTitle(wfMessage('hacl_acllist')->text());
         $wgOut->addModules('ext.intraacl.acllist');
         $wgOut->addHTML($html);
         $cfg = array();
@@ -576,7 +576,7 @@ class IntraACLSpecial extends SpecialPage
             $msg = 'hacl_acl_create_title';
         else
             $msg = 'hacl_acl_create';
-        $wgOut->setPageTitle(wfMsg($msg, $aclTitle ? $aclTitle->getText() : ''));
+        $wgOut->setPageTitle(wfMessage($msg, $aclTitle ? $aclTitle->getText() : '')->text());
         $wgOut->addModules('ext.intraacl.acleditor');
         $wgOut->addHTML($html);
         $cfg = array(
@@ -647,7 +647,7 @@ class IntraACLSpecial extends SpecialPage
         require(dirname(__FILE__).'/../templates/HACL_QuickACL.tpl.php');
         $html = ob_get_contents();
         ob_end_clean();
-        $wgOut->setPageTitle(wfMsg('hacl_qacl_manage'));
+        $wgOut->setPageTitle(wfMessage('hacl_qacl_manage')->text());
         $wgOut->addHTML($html);
     }
 
@@ -674,7 +674,7 @@ class IntraACLSpecial extends SpecialPage
         }
         foreach ($actions as $action)
         {
-            $a = '<b>'.wfMsg("hacl_action_$action").'</b>';
+            $a = '<b>'.wfMessage("hacl_action_$action")->text().'</b>';
             if ($act != $action)
             {
                 $url = "$wgScript?title=Special:IntraACL&action=$action";
@@ -696,7 +696,7 @@ class IntraACLSpecial extends SpecialPage
         require(dirname(__FILE__).'/../templates/HACL_GroupList.tpl.php');
         $html = ob_get_contents();
         ob_end_clean();
-        $wgOut->setPageTitle(wfMsg('hacl_grouplist'));
+        $wgOut->setPageTitle(wfMessage('hacl_grouplist')->text());
         $wgOut->addModules('ext.intraacl.grouplist');
         $wgOut->addHTML($html);
     }
@@ -730,7 +730,7 @@ class IntraACLSpecial extends SpecialPage
         $html = ob_get_contents();
         ob_end_clean();
         $wgOut->addModules('ext.intraacl.groupeditor');
-        $wgOut->setPageTitle($grpTitle ? wfMsg('hacl_grp_editing', $grpTitle->getText()) : wfMsg('hacl_grp_creating'));
+        $wgOut->setPageTitle($grpTitle ? wfMessage('hacl_grp_editing', $grpTitle->getText()->text()) : wfMessage('hacl_grp_creating')->text());
         $wgOut->addHTML($html);
         $cfg = array(
             'NS_ACL' => $wgContLang->getNsText(HACL_NS_ACL),
@@ -773,7 +773,7 @@ class IntraACLSpecial extends SpecialPage
                 $d['singletype'] = IACL::$typeToName[$s[0]];
                 $d['singlename'] = $d['single']->getText();
                 $d['singlelink'] = $d['single']->getLocalUrl();
-                $d['singletip'] = wfMsg('hacl_acllist_hint_single', $d['real'], $d['single']->getPrefixedText());
+                $d['singletip'] = wfMessage('hacl_acllist_hint_single', $d['real'], $d['single']->getPrefixedText())->text();
             }
             $lists[$d['type']][] = $d;
         }

--- a/includes/ParserFunctions.php
+++ b/includes/ParserFunctions.php
@@ -114,7 +114,7 @@ class IACLParserFunctions
     {
         if ($this->peType == IACL::PE_GROUP)
         {
-            return wfMsgForContent('hacl_invalid_parser_function', 'access');
+            return wfMessage('hacl_invalid_parser_function', 'access')->text();
         }
 
         $params = $this->getParameters($args);
@@ -128,7 +128,7 @@ class IACLParserFunctions
         $errMsgs = $em1 + $em2;
 
         // Format the defined right in Wikitext
-        $text = wfMsgForContent('hacl_pf_rights_title', implode(', ', $actions));
+        $text = wfMessage('hacl_pf_rights_title', implode(', ', $actions))->text();
         $text .= $this->showAssignees(array_keys($users), array_keys($groups));
         $text .= $this->showErrors($errMsgs);
 
@@ -150,7 +150,7 @@ class IACLParserFunctions
     {
         if ($this->peType == IACL::PE_GROUP)
         {
-            return wfMsgForContent('hacl_invalid_parser_function', 'predefined right');
+            return wfMessage('hacl_invalid_parser_function', 'predefined right')->text();
         }
 
         $params = $this->getParameters($args);
@@ -178,7 +178,7 @@ class IACLParserFunctions
         }
 
         // Format the rights in Wikitext
-        $text = wfMsgForContent('hacl_pf_predefined_rights_title');
+        $text = wfMessage('hacl_pf_predefined_rights_title')->text();
         $text .= $this->showRights(array_keys($rights));
         $text .= $this->showErrors($errors);
 
@@ -200,7 +200,7 @@ class IACLParserFunctions
         list($users, $groups, $errMsgs) = $this->assignedTo($params, 'assigned to', IACL::ACTION_MANAGE);
 
         // Format the right managers in Wikitext
-        $text = wfMsgForContent('hacl_pf_right_managers_title');
+        $text = wfMessage('hacl_pf_right_managers_title')->text();
         $text .= $this->showAssignees(array_keys($users), array_keys($groups));
         $text .= $this->showErrors($errMsgs);
 
@@ -218,7 +218,7 @@ class IACLParserFunctions
     {
         if ($this->peType != IACL::PE_GROUP)
         {
-            return wfMsgForContent('hacl_invalid_parser_function', 'predefined right');
+            return wfMessage('hacl_invalid_parser_function', 'predefined right')->text();
         }
 
         $params = $this->getParameters($args);
@@ -227,7 +227,7 @@ class IACLParserFunctions
         list($users, $groups, $errMsgs) = $this->assignedTo($params, 'members', IACL::ACTION_GROUP_MEMBER);
 
         // Format the group members in Wikitext
-        $text = wfMsgForContent('hacl_pf_group_members_title');
+        $text = wfMessage('hacl_pf_group_members_title')->text();
         $text .= $this->showAssignees(array_keys($users), array_keys($groups));
         $text .= $this->showErrors($errMsgs);
 
@@ -276,7 +276,7 @@ class IACLParserFunctions
         if (!isset($params[$param]))
         {
             // The parameter is missing
-            $errors[] = wfMsgForContent('hacl_missing_parameter', $param);
+            $errors[] = wfMessage('hacl_missing_parameter', $param)->text();
             return array($users, $groups, $errors);
         }
 
@@ -317,7 +317,7 @@ class IACLParserFunctions
             }
             else
             {
-                $errors[] = wfMsgForContent('hacl_unknown_user', $assignee);
+                $errors[] = wfMessage('hacl_unknown_user', $assignee)->text();
             }
         }
         // Get user IDs in a single pass
@@ -332,7 +332,7 @@ class IACLParserFunctions
             }
             foreach ($check as $invalid => $true)
             {
-                $errors[] = wfMsgForContent('hacl_unknown_user', $invalid);
+                $errors[] = wfMessage('hacl_unknown_user', $invalid)->text();
                 $this->badLinks[] = Title::makeTitleSafe(NS_USER, $invalid);
             }
         }
@@ -349,14 +349,14 @@ class IACLParserFunctions
             }
             foreach ($check as $invalid => $true)
             {
-                $errors[] = wfMsgForContent('hacl_unknown_group', $invalid);
+                $errors[] = wfMessage('hacl_unknown_group', $invalid)->text();
                 $this->badLinks[] = Title::makeTitleSafe(HACL_NS_ACL, $invalid);
             }
         }
         if (!$users && !$groups && !$all_reg)
         {
             // No users/groups specified at all => add error message
-            $errors[] = wfMsgForContent('hacl_missing_parameter_values', $param);
+            $errors[] = wfMessage('hacl_missing_parameter_values', $param)->text();
         }
         else
         {
@@ -426,7 +426,7 @@ class IACLParserFunctions
         if (!isset($params[$param]))
         {
             // The parameter "actions" is missing.
-            $errMsgs[] = wfMsgForContent('hacl_missing_parameter', $param);
+            $errMsgs[] = wfMessage('hacl_missing_parameter', $param)->text();
             return array($bitmask, $actions, $errMsgs);
         }
 
@@ -438,7 +438,7 @@ class IACLParserFunctions
             $id = $haclgContLang->getActionId($actions[$i]);
             if (!$id)
             {
-                $errMsgs[] = wfMsgForContent('hacl_invalid_action', $actions[$i]);
+                $errMsgs[] = wfMessage('hacl_invalid_action', $actions[$i])->text();
             }
             else
             {
@@ -447,7 +447,7 @@ class IACLParserFunctions
         }
         if (!$actions)
         {
-            $errMsgs[] = wfMsgForContent('hacl_missing_parameter_values', $param);
+            $errMsgs[] = wfMessage('hacl_missing_parameter_values', $param)->text();
         }
 
         return array($bitmask, $actions, $errMsgs);
@@ -469,7 +469,7 @@ class IACLParserFunctions
         if (!isset($params[$param]))
         {
             // The parameter "rights" is missing
-            $errMsgs[] = wfMsgForContent('hacl_missing_parameter', $param);
+            $errMsgs[] = wfMessage('hacl_missing_parameter', $param)->text();
             return array($rights, $errMsgs);
         }
 
@@ -488,18 +488,18 @@ class IACLParserFunctions
                     if ($result[$r][2] === NULL || !$subt->exists())
                     {
                         $this->badLinks[] = $subt;
-                        $errMsgs[] = wfMsgForContent('hacl_invalid_predefined_right', $subt);
+                        $errMsgs[] = wfMessage('hacl_invalid_predefined_right', $subt)->text();
                     }
                 }
                 else
                 {
-                    $errMsgs[] = wfMsgForContent('hacl_invalid_predefined_right', $r);
+                    $errMsgs[] = wfMessage('hacl_invalid_predefined_right', $r)->text();
                 }
             }
         }
         if (!$result)
         {
-            $errMsgs[] = wfMsgForContent('hacl_missing_parameter_values', $param);
+            $errMsgs[] = wfMessage('hacl_missing_parameter_values', $param)->text();
         }
 
         return array($result, $errMsgs);
@@ -536,29 +536,29 @@ class IACLParserFunctions
                 {
                     $editor = false;
                     $html .= '<div class="error"><p>'.
-                        wfMsgForContent('hacl_non_canonical_acl_new', Title::newFromText($sdName)->getLocalUrl(), $sdName, $old).'</p></div>';
+                        wfMessage('hacl_non_canonical_acl_new', Title::newFromText($sdName)->getLocalUrl(), $sdName, $old)->text().'</p></div>';
                 }
                 else
                 {
                     $html .= '<div class="error"><p>'.
-                        wfMsgForContent('hacl_non_canonical_acl', SpecialPage::getTitleFor('MovePage', $old)
-                        ->getLocalUrl(array('wpLeaveRedirect' => 0, 'wpNewTitle' => $sdName)), $sdName, $old).'</p></div>';
+                        wfMessage('hacl_non_canonical_acl', SpecialPage::getTitleFor('MovePage', $old)
+                        ->getLocalUrl(array('wpLeaveRedirect' => 0, 'wpNewTitle' => $sdName)), $sdName, $old)->text().'</p></div>';
                 }
             }
             // Add "Create/edit with IntraACL editor" link
             if ($editor && $article->getTitle()->userCan('edit'))
             {
-                $html .= wfMsgForContent($self->def && $self->def->clean() ? 'hacl_edit_with_special' : 'hacl_create_with_special',
+                $html .= wfMessage($self->def && $self->def->clean() ? 'hacl_edit_with_special' : 'hacl_create_with_special',
                     Title::newFromText('Special:IntraACL')->getLocalUrl(array(
                         'action' => ($self->peType == IACL::PE_GROUP ? 'group' : 'acl'),
                         ($self->peType == IACL::PE_GROUP ? 'group' : 'sd') => $self->title->getPrefixedText(),
                     )),
-                    $haclgHaloScriptPath . '/skins/images/edit.png');
+                    $haclgHaloScriptPath . '/skins/images/edit.png')->text();
                 if ($self->peType == IACL::PE_CATEGORY)
                 {
                     // Add "This is category ACL, see category page ACL here"
                     $pa = Title::newFromText(IACLDefinition::nameOfSD(IACL::PE_PAGE, 'Category:'.$self->peName));
-                    $html .= wfMsgForContent('hacl_category_acl_shown', $pa->getPrefixedText(), $pa->getLocalUrl(), $haclgHaloScriptPath . '/skins/images/warn.png');
+                    $html .= wfMessage('hacl_category_acl_shown', $pa->getPrefixedText(), $pa->getLocalUrl(), $haclgHaloScriptPath . '/skins/images/warn.png')->text();
                 }
                 elseif ($self->peType == IACL::PE_PAGE)
                 {
@@ -567,13 +567,13 @@ class IACLParserFunctions
                     {
                         // Add "This is category page ACL, see category ACL here"
                         $pa = Title::newFromText(IACLDefinition::nameOfSD(IACL::PE_CATEGORY, $peTitle->getText()));
-                        $html .= wfMsgForContent('hacl_category_page_acl_shown', $pa->getPrefixedText(), $pa->getLocalUrl(), $haclgHaloScriptPath . '/skins/images/warn.png');
+                        $html .= wfMessage('hacl_category_page_acl_shown', $pa->getPrefixedText(), $pa->getLocalUrl(), $haclgHaloScriptPath . '/skins/images/warn.png')->text();
                     }
                     elseif (MWNamespace::hasSubpages($peTitle->getNamespace()))
                     {
                         // Add "This is page ACL, see tree ACL here"
                         $pa = Title::newFromText(IACLDefinition::nameOfSD(IACL::PE_TREE, $peTitle->getText()));
-                        $html .= wfMsgForContent('hacl_page_acl_shown', $pa->getPrefixedText(), $pa->getLocalUrl(), $haclgHaloScriptPath . '/skins/images/warn.png');
+                        $html .= wfMessage('hacl_page_acl_shown', $pa->getPrefixedText(), $pa->getLocalUrl(), $haclgHaloScriptPath . '/skins/images/warn.png')->text();
                     }
                 }
                 elseif ($self->peType == IACL::PE_TREE)
@@ -581,7 +581,7 @@ class IACLParserFunctions
                     // Add "This is tree ACL, see page ACL here"
                     $peTitle = Title::newFromText($self->peName);
                     $pa = Title::newFromText(IACLDefinition::nameOfSD(IACL::PE_PAGE, $peTitle->getText()));
-                    $html .= wfMsgForContent('hacl_tree_acl_shown', $pa->getPrefixedText(), $pa->getLocalUrl(), $haclgHaloScriptPath . '/skins/images/warn.png');
+                    $html .= wfMessage('hacl_tree_acl_shown', $pa->getPrefixedText(), $pa->getLocalUrl(), $haclgHaloScriptPath . '/skins/images/warn.png')->text();
                 }
             }
             $wgOut->addHTML($html);
@@ -972,13 +972,13 @@ class IACLParserFunctions
             if ($newSDTitle->exists() && $newSDTitle->userCan('delete'))
             {
                 $page = new WikiPage($newSDTitle);
-                $page->doDeleteArticle(wfMsg('hacl_move_acl'));
+                $page->doDeleteArticle(wfMessage('hacl_move_acl')->text());
             }
             else
             {
                 // FIXME report "permission denied to overwrite $to"
             }
-            $oldSDTitle->moveTo($newSDTitle, false, wfMsg('hacl_move_acl'), true);
+            $oldSDTitle->moveTo($newSDTitle, false, wfMessage('hacl_move_acl')->text(), true);
         }
         self::refreshBadlinks($newTitle);
 
@@ -1009,38 +1009,38 @@ class IACLParserFunctions
         $this->makeDef();
         if ($this->errors)
         {
-            $msg[] = wfMsgForContent('hacl_errors_in_definition');
+            $msg[] = wfMessage('hacl_errors_in_definition')->text();
         }
         $sdName = self::getCanonicalDefTitle($this->title);
         if ($sdName !== NULL && $sdName != $this->title->getPrefixedText())
         {
-            $msg[] = wfMsgForContent('hacl_non_canonical_acl_short', $sdName);
+            $msg[] = wfMessage('hacl_non_canonical_acl_short', $sdName)->text();
         }
         if ($this->isUnprotectable())
         {
             // This namespace can not be protected
-            $msg[] = wfMsgForContent('hacl_unprotectable_namespace');
+            $msg[] = wfMessage('hacl_unprotectable_namespace')->text();
         }
         if ($this->title->exists() && !$this->rules)
         {
             if ($this->peType == IACL::PE_GROUP)
             {
-                $msg[] = wfMsgForContent('hacl_group_must_have_members');
+                $msg[] = wfMessage('hacl_group_must_have_members')->text();
             }
             else
             {
-                $msg[] = wfMsgForContent('hacl_right_must_have_rights');
+                $msg[] = wfMessage('hacl_right_must_have_rights')->text();
             }
         }
         if (!$this->def)
         {
             if ($this->isInterwiki)
             {
-                $msg[] = wfMsgForContent('hacl_pe_is_interwiki', $this->peName);
+                $msg[] = wfMessage('hacl_pe_is_interwiki', $this->peName)->text();
             }
             else
             {
-                $msg[] = wfMsgForContent('hacl_pe_not_exists', $this->peName);
+                $msg[] = wfMessage('hacl_pe_not_exists', $this->peName)->text();
             }
         }
         else
@@ -1049,7 +1049,7 @@ class IACLParserFunctions
             if ($del || $add)
             {
                 // TODO Show inconsistency details
-                $msg[] = wfMsgForContent('hacl_acl_element_inconsistent');
+                $msg[] = wfMessage('hacl_acl_element_inconsistent')->text();
             }
         }
         if (!$asHtml)
@@ -1060,7 +1060,7 @@ class IACLParserFunctions
         $html = '';
         if ($msg)
         {
-            $html .= wfMsgForContent('hacl_consistency_errors');
+            $html .= wfMessage('hacl_consistency_errors')->text();
             $html .= "<ul>";
             foreach ($msg as $m)
             {
@@ -1089,17 +1089,17 @@ class IACLParserFunctions
             global $wgContLang;
             $userNS = $wgContLang->getNsText(NS_USER);
             $text .= $isAssignedTo
-                ? ':;'.wfMsgForContent('hacl_assigned_user')
-                : ':;'.wfMsgForContent('hacl_user_member');
+                ? ':;'.wfMessage('hacl_assigned_user')->text()
+                : ':;'.wfMessage('hacl_user_member')->text();
             foreach ($users as &$u)
             {
                 if ($u == '*')
                 {
-                    $u = wfMsgForContent('hacl_all_users');
+                    $u = wfMessage('hacl_all_users')->text();
                 }
                 elseif ($u == '#')
                 {
-                    $u = wfMsgForContent('hacl_registered_users');
+                    $u = wfMessage('hacl_registered_users')->text();
                 }
                 else
                 {
@@ -1114,8 +1114,8 @@ class IACLParserFunctions
             global $wgContLang;
             $aclNS = $wgContLang->getNsText(HACL_NS_ACL);
             $text .= $isAssignedTo
-                ? ':;'.wfMsgForContent('hacl_assigned_groups')
-                : ':;'.wfMsgForContent('hacl_group_member');
+                ? ':;'.wfMessage('hacl_assigned_groups')->text()
+                : ':;'.wfMessage('hacl_group_member')->text();
             $first = true;
             foreach ($groups as $g)
             {
@@ -1147,8 +1147,8 @@ class IACLParserFunctions
         {
             if (!$this->errors)
             {
-                $text .= "\n:;".wfMsgForContent('hacl_error').
-                    wfMsgForContent('hacl_will_not_work_as_expected');
+                $text .= "\n:;".wfMessage('hacl_error')->text().
+                    wfMessage('hacl_will_not_work_as_expected')->text();
             }
             $text .= "\n:*".implode("\n:*", $messages);
         }

--- a/includes/SpecialSelftest.php
+++ b/includes/SpecialSelftest.php
@@ -65,15 +65,15 @@ class IntraACLSelftestSpecial extends SpecialPage
         }
         else
         {
-            $wgOut->setPageTitle(wfMsg('iacl-selftest-title'));
-            $wgOut->addWikiText(wfMsgNoTrans('iacl-selftest-info', $wgTitle->getFullUrl(array('do' => 1, 'quiet' => 1))));
+            $wgOut->setPageTitle(wfMessage('iacl-selftest-title')->text());
+            $wgOut->addWikiText(wfMessage('iacl-selftest-info', $wgTitle->getFullUrl(array('do' => 1, 'quiet' => 1)))->plain());
             $wgOut->addHTML('<iframe style="border-width: 0; width: 100%; height: 500px" src="'.$wgTitle->getLocalUrl(array('do' => 1)).'"></iframe>');
         }
     }
 
     static function loadConfig()
     {
-        $msg = wfMessage('IntraACL right tests');
+        $msg = wfMessage('IntraACL right tests')->text();
         $pages = array();
         if (!$msg->isBlank())
         {

--- a/includes/Toolbar.php
+++ b/includes/Toolbar.php
@@ -59,8 +59,8 @@ class IACLToolbar
         $ns = $wgContLang->getNsText(HACL_NS_ACL);
         $options = array(array(
             'value' => 'unprotected',
-            'name' => wfMsg('hacl_toolbar_unprotected'),
-            'title' => wfMsg('hacl_toolbar_unprotected'),
+            'name' => wfMessage('hacl_toolbar_unprotected')->text(),
+            'title' => wfMessage('hacl_toolbar_unprotected')->text(),
         ));
 
         if (!is_object($title))
@@ -348,7 +348,7 @@ class IACLToolbar
         $pe = self::getReadableCategories();
         if (!$pe)
         {
-            return wfMsgNoTrans($for_upload ? 'hacl_nonreadable_upload_nocat' : 'hacl_nonreadable_create_nocat');
+            return wfMessage($for_upload ? 'hacl_nonreadable_upload_nocat' : 'hacl_nonreadable_create_nocat')->plain();
         }
         if ($for_upload)
         {
@@ -364,7 +364,7 @@ class IACLToolbar
                 '\''.$for_upload.')">'.
                 htmlspecialchars($cat->getText()).'</a>';
         }
-        return wfMsgNoTrans($for_upload ? 'hacl_nonreadable_upload' : 'hacl_nonreadable_create', implode(', ', $select));
+        return wfMessage($for_upload ? 'hacl_nonreadable_upload' : 'hacl_nonreadable_create', implode(', ', $select))->plain();
     }
 
     /**
@@ -600,12 +600,12 @@ class IACLToolbar
             $selectedSDTitle = IACLDefinition::getSDTitle($selectedSD);
             $content = '{{#predefined right: '.$selectedSDTitle->getText()."}}\n".
                 '{{#manage rights: assigned to = User:'.$wgUser->getName()."}}\n";
-            $newSDArticle->doEdit($content, wfMsg('hacl_comment_protect_with', $selectedSDTitle->getFullText()));
+            $newSDArticle->doEdit($content, wfMessage('hacl_comment_protect_with', $selectedSDTitle->getFullText())->text());
         }
         else
         {
             // Remove page SD
-            $newSDArticle->doDeleteArticle(wfMsg('hacl_comment_unprotect'));
+            $newSDArticle->doDeleteArticle(wfMessage('hacl_comment_unprotect'))->text();
         }
 
         // Continue hook processing
@@ -689,7 +689,7 @@ class IACLToolbar
                     // Save embedded element SD
                     $emb_sd_article->doEdit(
                         '{{#predefined right: '.$articleSD['def_title'].'}}',
-                        wfMsg('hacl_comment_protect_embedded', ''.$articleSD['def_title']),
+                        wfMessage('hacl_comment_protect_embedded', ''.$articleSD['def_title'])->text(),
                         EDIT_FORCE_BOT
                     );
                 }
@@ -702,15 +702,15 @@ class IACLToolbar
         {
             foreach ($errors as &$e)
             {
-                $e = "[[:".$e[0]->getPrefixedText()."]] (".wfMsg('hacl_embedded_error_'.$e[1]).")";
+                $e = "[[:".$e[0]->getPrefixedText()."]] (".wfMessage('hacl_embedded_error_'.$e[1])->text().")";
             }
             $wgOut->setTitle(Title::newFromText('Special:IntraACL'));
-            $wgOut->addWikiText(wfMsgNoTrans(
+            $wgOut->addWikiText(wfMessage(
                 'hacl_embedded_not_saved',
                 implode(", ", $errors),
                 $article->getTitle()->getPrefixedText()
-            ));
-            $wgOut->setPageTitle(wfMsg('hacl_embedded_not_saved_title'));
+            )->plain());
+            $wgOut->setPageTitle(wfMessage('hacl_embedded_not_saved_title')->text());
             $wgOut->output();
             // FIXME terminate MediaWiki more correctly
             wfGetDB(DB_MASTER)->commit();
@@ -773,12 +773,12 @@ class IACLToolbar
                 if ($link['sd_single'])
                 {
                     // Already protected by page SD
-                    $customprot = wfMsgForContent('hacl_toolbar_emb_already_prot');
+                    $customprot = wfMessage('hacl_toolbar_emb_already_prot')->text();
                 }
                 else
                 {
                     // Custom SD defined
-                    $customprot = wfMsgForContent('hacl_toolbar_emb_custom_prot', $link['sd_title']->getLocalUrl());
+                    $customprot = wfMessage('hacl_toolbar_emb_custom_prot', $link['sd_title']->getLocalUrl())->text();
                 }
             }
             else
@@ -788,7 +788,7 @@ class IACLToolbar
             if ($link['used_on_pages'] > 1)
             {
                 $usedon = Title::newFromText("Special:WhatLinksHere/$t")->getLocalUrl(array('hidelinks' => 1));
-                $usedon = wfMsgForContent('hacl_toolbar_used_on', $link['used_on_pages'], $usedon);
+                $usedon = wfMessage('hacl_toolbar_used_on', $link['used_on_pages'], $usedon)->text();
             }
             else
             {
@@ -816,16 +816,16 @@ class IACLToolbar
         {
             $html[] = '<div class="hacl_embed"><input type="checkbox" id="hacl_emb_all" onchange="hacle_checkall(this, ['.
                 implode(',',$all).'])" onclick="hacle_checkall(this, ['.implode(',',$all).'])" /> '.
-                wfMsg('hacl_toolbar_emb_all').'</div>';
+                wfMessage('hacl_toolbar_emb_all')->text().'</div>';
         }
         elseif ($html)
         {
             $html[] = '<div class="hacl_embed_disabled"><input type="checkbox" disabled="disabled" checked="checked" /> '.
-                wfMsg('hacl_toolbar_emb_all_already').'</div>';
+                wfMessage('hacl_toolbar_emb_all_already')->text().'</div>';
         }
         if ($html)
         {
-            array_unshift($html, '<div class="hacl_emb_text">'.wfMsgForContent('hacl_toolbar_protect_embedded').'</div>');
+            array_unshift($html, '<div class="hacl_emb_text">'.wfMessage('hacl_toolbar_protect_embedded')->text().'</div>');
         }
         $html = implode("\n", $html);
         return $html;
@@ -890,7 +890,7 @@ class IACLToolbar
                 $title = $peType == IACL::PE_PAGE ? Title::newFromText($peName) : Title::makeTitleSafe(NS_CATEGORY, $peName);
                 return array(
                     'class' => false,
-                    'text'  => wfMsg("hacl_tab_".IACL::$typeToName[$peType]),
+                    'text'  => wfMessage("hacl_tab_".IACL::$typeToName[$peType])->text(),
                     'href'  => $title->getLocalUrl(),
                 );
             }
@@ -916,7 +916,7 @@ class IACLToolbar
             }
             return array(
                 'class' => $sd->exists() ? false : 'new',
-                'text'  => wfMsg('hacl_tab_acl'),
+                'text'  => wfMessage('hacl_tab_acl')->text(),
                 'href'  => $sd->getLocalUrl(),
             );
         }


### PR DESCRIPTION
Replaces deprecated functions wfMsg* by wfMessage according to:
https://www.mediawiki.org/wiki/Manual:Messages_API#Help_with_replacing_deprecated_wfMsg.2A_functions